### PR TITLE
Fix TextAreaFixed display name

### DIFF
--- a/src/forms/TextInput.tsx
+++ b/src/forms/TextInput.tsx
@@ -43,4 +43,4 @@ export const TextAreaFixed = forwardRef<HTMLSpanElement, TextAreaProps>((props, 
     return <TextAreaUIKit ref={ref} {...props} controlRef={controlRef} autoFocus={false} />;
 });
 
-TextAreaFixed.displayName = 'TextInputFixed';
+TextAreaFixed.displayName = 'TextAreaFixed';


### PR DESCRIPTION
## Summary
- fix `TextAreaFixed.displayName` so React devtools show the correct component name