### PR TITLE
Fix wysiwyg clickable area

### DIFF
--- a/src/bundle/WysiwygEditorView.scss
+++ b/src/bundle/WysiwygEditorView.scss
@@ -11,6 +11,8 @@
     &__editor {
         overflow-y: auto;
         flex-grow: 1;
+        // Ensure empty editor has clickable area
+        min-height: 36px;
 
         padding: var(--g-md-editor-padding);
 

--- a/tests/visual-tests/ClickableArea.visual.test.tsx
+++ b/tests/visual-tests/ClickableArea.visual.test.tsx
@@ -1,0 +1,16 @@
+import {test, expect} from 'playwright/core';
+import {PresetsStories} from './Presets.helpers';
+
+const getHeights = async (page) => {
+    const container = page.locator('.g-md-wysiwyg-editor__editor');
+    const editor = container.locator('.ProseMirror');
+    const containerBox = await container.boundingBox();
+    const editorBox = await editor.boundingBox();
+    return {containerHeight: containerBox?.height, editorHeight: editorBox?.height};
+};
+
+test('zero preset clickable area', async ({mount, page}) => {
+    await mount(<PresetsStories.Zero />);
+    const {containerHeight, editorHeight} = await getHeights(page);
+    expect(containerHeight).toBeCloseTo(editorHeight!, 1);
+});


### PR DESCRIPTION
## Summary
- add regression test for wysiwyg editor height
- ensure wysiwyg editor's editable area has minimum height

## Testing
- `npm test`
- `npx playwright test tests/visual-tests/ClickableArea.visual.test.tsx --project=chromium --workers=1 --config=tests/playwright/playwright.config.ts` *(fails: JS heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_686b17180a98832481dcc8358c9b50d3