### PR TITLE
fix: avoid ellipsis substitution in code

### DIFF
--- a/src/extensions/base/BaseInputRules/BaseInputRules.test.ts
+++ b/src/extensions/base/BaseInputRules/BaseInputRules.test.ts
@@ -1,0 +1,66 @@
+import {EditorState, TextSelection} from 'prosemirror-state';
+import {EditorView} from 'prosemirror-view';
+import {builders} from 'prosemirror-test-builder';
+
+import {ExtensionsManager} from '../../../core';
+import {BaseSchemaSpecs, BaseNode} from '../specs';
+import {CodeSpecs, codeMarkName} from '../../markdown/Code/CodeSpecs';
+import {BaseInputRules} from './index';
+
+const {
+    schema,
+    plugins,
+} = new ExtensionsManager({
+    extensions: (builder) =>
+        builder.use(BaseSchemaSpecs, {}).use(CodeSpecs).use(BaseInputRules),
+}).build();
+
+const {doc, p, c} = builders<'doc' | 'p', 'c'>(schema, {
+    doc: {nodeType: BaseNode.Doc},
+    p: {nodeType: BaseNode.Paragraph},
+    c: {markType: codeMarkName},
+});
+
+describe('BaseInputRules ellipsis', () => {
+    it('does not replace triple dots inside inline code', () => {
+        const startDoc = doc(p(c('text<a>')));
+        const state = EditorState.create({
+            schema,
+            doc: startDoc,
+            selection: TextSelection.create(startDoc, startDoc.tag.a),
+            plugins,
+        });
+        const view = new EditorView(document.createElement('div'), {state});
+
+        const handled = view.someProp('handleTextInput', (f: any) =>
+            f(view, startDoc.tag.a, startDoc.tag.a, '...'),
+        );
+
+        if (!handled) {
+            view.dispatch(view.state.tr.insertText('...', startDoc.tag.a, startDoc.tag.a));
+        }
+
+        expect(view.state.doc).toMatchNode(doc(p(c('text...'))));
+    });
+
+    it('replaces triple dots in regular text', () => {
+        const startDoc = doc(p('text<a>'));
+        const state = EditorState.create({
+            schema,
+            doc: startDoc,
+            selection: TextSelection.create(startDoc, startDoc.tag.a),
+            plugins,
+        });
+        const view = new EditorView(document.createElement('div'), {state});
+
+        const handled = view.someProp('handleTextInput', (f: any) =>
+            f(view, startDoc.tag.a, startDoc.tag.a, '...'),
+        );
+
+        if (!handled) {
+            view.dispatch(view.state.tr.insertText('...', startDoc.tag.a, startDoc.tag.a));
+        }
+
+        expect(view.state.doc).toMatchNode(doc(p('text…')));
+    });
+});

--- a/src/extensions/base/BaseInputRules/index.ts
+++ b/src/extensions/base/BaseInputRules/index.ts
@@ -1,7 +1,13 @@
-import {ellipsis} from 'prosemirror-inputrules';
+import {InputRule} from 'prosemirror-inputrules';
 
 import type {ExtensionAuto} from '../../../core';
+import {hasCodeMark} from '../../../utils/inputrules';
+
+const ellipsisInputRule = new InputRule(/\.\.\.$/, (state, match, start, end) => {
+    if (hasCodeMark(state, match, start, end)) return null;
+    return state.tr.insertText('…', start, end);
+});
 
 export const BaseInputRules: ExtensionAuto = (builder) => {
-    builder.addInputRules(() => ({rules: [ellipsis]}));
+    builder.addInputRules(() => ({rules: [ellipsisInputRule]}));
 };


### PR DESCRIPTION
## Summary
- avoid converting `...` to ellipsis within inline code
- add tests ensuring ellipsis still works in regular text

## Testing
- `npm test`
- `npx jest src/extensions/base/BaseInputRules/BaseInputRules.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_6899ea96bc9083248b74343fdaa8eb75